### PR TITLE
block user & refacto users relation

### DIFF
--- a/app/Events/SubscriptionEvent.php
+++ b/app/Events/SubscriptionEvent.php
@@ -3,7 +3,7 @@
 namespace App\Events;
 
 use App\Models\User;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
@@ -23,7 +23,7 @@ class SubscriptionEvent implements ShouldBroadcast
     /**
      * Create a new notification instance.
      */
-    public function __construct(Subscription $subscription)
+    public function __construct(UsersRelation $subscription)
     {
         $this->subscription = $subscription;
         $this->message = $this->subscription->status == "pending" ?

--- a/app/Http/Controllers/Api/NotificationsController.php
+++ b/app/Http/Controllers/Api/NotificationsController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Comment;
 use App\Models\Like;
 use App\Models\Post;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use App\Models\User;
 use App\Services\UserService;
 
@@ -49,7 +49,7 @@ class NotificationsController extends Controller
                 $notif["notification"] = $notification;
             }
             if (isset($notification->data["subscription_id"])) {
-                $subscription = Subscription::where('id', $notification->data["subscription_id"])->firstOrFail();
+                $subscription = UsersRelation::where('id', $notification->data["subscription_id"])->firstOrFail();
                 $notif["subscription"] = $subscription;
                 $user = User::where('id', $subscription->follower_id)->firstOrFail();
                 $user->reward;

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -39,7 +39,7 @@ class PostController extends Controller
         $postsOfUserCommunity = [];
 
         foreach ($posts as $post) {
-            if ($this->userService->checkIfCanAccessToRessource($post->author_id)) {
+            if ($this->userService->checkIfCanAccessToRessource($post->author_id) && $this->userService->isUserUnblocked($post->author_id)) {
                 foreach ($post->userPostParticipation as $userPostParticipation) {
                     $userPostParticipation->users;
                 }
@@ -117,8 +117,8 @@ class PostController extends Controller
     public function show(int $id)
     {
         $post = Post::where('id', $id)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($post->author_id)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($post->author_id) || !$this->userService->isUserUnblocked($post->author_id)) {
+            return response()->json(['error' => 'Access denied'], 400);
         }
 
         if (!$post) {

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -118,7 +118,7 @@ class PostController extends Controller
     {
         $post = Post::where('id', $id)->firstOrFail();
         if (!$this->userService->checkIfCanAccessToRessource($post->author_id) || !$this->userService->isUserUnblocked($post->author_id)) {
-            return response()->json(['error' => 'Access denied'], 400);
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         if (!$post) {

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -24,9 +24,9 @@ class SearchController extends Controller
         // Participants list with details
         $users = $this->userService->searchByUsernameOrEmail($q);
         $result['users'] = $users;
-
+        
         // Posts list with details
-        $posts = $this->postService->searchByTitleOrDescriptionOrTag($q);
+        $posts = $this->postService->searchPost($q);
         $result['posts'] = $posts;
 
         return response()->json($result);

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -35,7 +35,7 @@ class UserController extends Controller
   public function show(int $userId)
   {
     $user = User::findOrFail($userId);
-    
+
     $user->badge;
     $user->total_point = $this->userPointService->userTotalPoints($user->id);
 
@@ -43,6 +43,11 @@ class UserController extends Controller
       $user->userTrophy = [];
       $user->userPostParticipation = [];
       $user->follower = [];
+      $user->following = [];
+    } else if (!$this->userService->isUserUnblocked($user->id)) {
+      $user->userTrophy = [];
+      $user->userPostParticipation = [];
+      $user->follower->load('follower')->where('follower_id', $user->id)->first();
       $user->following = [];
     } else {
       $user->userTrophy;

--- a/app/Http/Controllers/Api/UserPointCategoryController.php
+++ b/app/Http/Controllers/Api/UserPointCategoryController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use App\Models\User;
 use App\Models\UserPointCategory;
 use Illuminate\Http\Request;
@@ -32,7 +32,7 @@ class UserPointCategoryController extends Controller
             return response()->json(['error' => 'User not found.'], 404);
         }
         if ($user->is_private) {
-            $userAuthenticatedFollowing =  Subscription::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
+            $userAuthenticatedFollowing =  UsersRelation::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
             if ($userAuthenticatedFollowing->count() < 1  && $userId != $userAuthenticated->id) {
                 return response()->json(['error' => 'User private'], 400);
             }
@@ -91,7 +91,7 @@ class UserPointCategoryController extends Controller
             return response()->json(['error' => 'User not found.'], 404);
         }
         if ($user->is_private) {
-            $userAuthenticatedFollowing =  Subscription::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
+            $userAuthenticatedFollowing =  UsersRelation::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
             if ($userAuthenticatedFollowing->count() < 1  && $userId != $userAuthenticated->id) {
                 return response()->json(['error' => 'User private'], 400);
             }

--- a/app/Http/Controllers/Api/UserPostParticipationController.php
+++ b/app/Http/Controllers/Api/UserPostParticipationController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Models\Reward;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use App\Models\UserPostParticipation;
 use App\Services\PostService;
 use App\Services\UserPointService;
@@ -95,8 +95,8 @@ class UserPostParticipationController extends Controller
         $userPostParticipation = UserPostParticipation::where('id', $id)->firstOrFail();
 
         $user = User::where('id', $userPostParticipation->participant_id)->first();
-        if (!$this->userService->checkIfCanAccessToRessource($user->id)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($user->id) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         if (!$userPostParticipation) {
@@ -168,8 +168,8 @@ class UserPostParticipationController extends Controller
         if (!$userAuthenticated || !$user) {
             return response()->json(['error' => 'User not found.'], 404);
         }
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where('participant_id', $user->id)->get();
@@ -183,8 +183,8 @@ class UserPostParticipationController extends Controller
     public function getPostsByUserCompleted(int $userId)
     {
         $user = User::where('id', $userId)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where(['participant_id' => $user->id, 'is_completed' => true])->get();
@@ -211,8 +211,8 @@ class UserPostParticipationController extends Controller
     public function getPostsByUserAbandoned(int $userId)
     {
         $user = User::where('id', $userId)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where(['participant_id' => $user->id, 'is_completed' => false])->get();
@@ -243,8 +243,8 @@ class UserPostParticipationController extends Controller
     {
         $user = User::where('id', $userId)->firstOrFail();
         $user = User::where('id', $userId)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where(['participant_id' => $user->id, 'is_completed' => false])->get();
@@ -276,8 +276,8 @@ class UserPostParticipationController extends Controller
     public function getPostsByUserNext(int $userId)
     {
         $user = User::where('id', $userId)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where(['participant_id' => $user->id, 'is_completed' => false])->get();
@@ -307,8 +307,8 @@ class UserPostParticipationController extends Controller
     public function getUserActions(int $userId)
     {
         $user = User::where('id', $userId)->firstOrFail();
-        if (!$this->userService->checkIfCanAccessToRessource($userId)) {
-            return response()->json(['error' => 'User private'], 400);
+        if (!$this->userService->checkIfCanAccessToRessource($userId) || !$this->userService->isUserUnblocked($user->id)) {
+            return response()->json(['error' => 'Access denied'], 403);
         }
 
         $userPostParticipations = UserPostParticipation::where(['participant_id' => $user->id, 'is_completed' => true])->get();

--- a/app/Http/Controllers/Api/UserTrophyController.php
+++ b/app/Http/Controllers/Api/UserTrophyController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Category;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use App\Models\User;
 use App\Models\UserTrophy;
 use Illuminate\Http\Request;
@@ -30,7 +30,7 @@ class UserTrophyController extends Controller
             return response()->json(['error' => 'User not found.'], 404);
         }
         if ($user->is_private) {
-            $userAuthenticatedFollowing = Subscription::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
+            $userAuthenticatedFollowing = UsersRelation::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
             if ($userAuthenticatedFollowing->count() < 1 && $userId != $userAuthenticated->id) {
                 return response()->json(['error' => 'User private'], 400);
             }
@@ -85,7 +85,7 @@ class UserTrophyController extends Controller
             return response()->json(['error' => 'User not found.'], 404);
         }
         if ($user->is_private) {
-            $userAuthenticatedFollowing = Subscription::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
+            $userAuthenticatedFollowing = UsersRelation::where(['status' => 'approved', 'following_id' => $user->id, 'follower_id' => $userAuthenticated->id]);
             if ($userAuthenticatedFollowing->count() < 1 && $userId != $userAuthenticated->id) {
                 return response()->json(['error' => 'User private'], 400);
             }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -19,8 +19,8 @@ class Tag extends Model
         'label',
     ];
 
-    public function posts()
+    public function tag_post()
     {
-        return $this->belongsToMany(Post::class, 'tag_post', 'tag_id', 'post_id');
+        return $this->hasMany(TagPost::class);
     }
 }

--- a/app/Models/TagPost.php
+++ b/app/Models/TagPost.php
@@ -21,13 +21,11 @@ class TagPost extends Model
 
     public function tags()
     {
-        return $this->hasMany(Tag::class, 'tag_id', '');
+        return $this->belongsTo(Tag::class, 'tag_id');
     }
 
     public function posts()
     {
-        return $this->hasMany(Post::class, 'post_id');
+        return $this->belongsTo(Post::class, 'post_id');
     }
-
-
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,7 +7,7 @@ use App\Models\Comment;
 use App\Models\Like;
 use App\Models\Reward;
 use App\Models\Post;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use App\Models\UserPointCategory;
 use App\Models\UserPostParticipation;
 use App\Models\UserTrophy;
@@ -78,12 +78,12 @@ class User extends Authenticatable
 
     public function following()
     {
-        return $this->hasMany(Subscription::class, 'follower_id');
+        return $this->hasMany(UsersRelation::class, 'follower_id');
     }
 
     public function follower()
     {
-        return $this->hasMany(Subscription::class, 'following_id');
+        return $this->hasMany(UsersRelation::class, 'following_id');
     }
 
     public function like()

--- a/app/Models/UsersRelation.php
+++ b/app/Models/UsersRelation.php
@@ -6,12 +6,12 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Subscription extends Model
+class UsersRelation extends Model
 {
     use HasFactory;
 
     
-    protected $table = 'subscriptions';
+    protected $table = 'users_relation';
 
     protected $fillable = [
         'id',

--- a/app/Notifications/UserSubscribed.php
+++ b/app/Notifications/UserSubscribed.php
@@ -3,7 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\User;
-use App\Models\Subscription;
+use App\Models\UsersRelation;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -20,7 +20,7 @@ class UserSubscribed extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct(Subscription $subscription, User $user)
+    public function __construct(UsersRelation $subscription, User $user)
     {
         $this->user = $user;
         $this->subscription = $subscription;

--- a/app/Services/TagService.php
+++ b/app/Services/TagService.php
@@ -15,7 +15,7 @@ class TagService
     {
         $allTags = Tag::get();
         $tagsToAttach = [];
-        
+
         foreach ($tags as $tag) {
             if (!in_array($tag['label'], $allTags->pluck('label')->toArray())) {
                 $newTag = Tag::create(['label' => $tag['label']]);
@@ -57,5 +57,17 @@ class TagService
         $postUpdated = $post;
 
         return $postUpdated;
+    }
+
+    public function searchTag(string $q)
+    {
+        $tags = Tag::where('label', 'ILIKE', '%' . $q . '%')->take(5)->get();
+        $res = [];
+        foreach ($tags as $tag) {
+            foreach ($tag->tag_post as $tag_post) {
+                $res[] = $tag_post->load('posts')->posts;
+            }
+        }
+        return $res;
     }
 }

--- a/database/migrations/2023_10_05_095115_create_users_relation_table.php
+++ b/database/migrations/2023_10_05_095115_create_users_relation_table.php
@@ -10,7 +10,7 @@ return new class extends Migration {
      */
     public function up(): void
     {
-        Schema::create('subscriptions', function (Blueprint $table) {
+        Schema::create('users_relation', function (Blueprint $table) {
             $table->id();
             $table->foreignId('follower_id')->constrained(
                 table: 'users',
@@ -20,7 +20,7 @@ return new class extends Migration {
                 table: 'users',
                 indexName: 'following_id'
             )->cascadeOnDelete();
-            $table->enum('status', ['approved', 'pending', 'denied']);
+            $table->enum('status', ['approved', 'pending', 'denied', 'blocked']);
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,7 +11,7 @@ use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\UserPointCategoryController;
 use App\Http\Controllers\Api\UserPostParticipationController;
 use App\Http\Controllers\Api\UserTrophyController;
-use App\Http\Controllers\Api\SubscriptionController;
+use App\Http\Controllers\Api\UsersRelationController;
 use App\Http\Controllers\Api\TagController;
 use App\Http\Controllers\Api\ReportController;
 use App\Http\Controllers\Api\ImageController;
@@ -92,11 +92,14 @@ Route::middleware('auth:sanctum')->group(function () {
     //Search
     Route::get('/search/{q}', [SearchController::class, 'getResult']);
     
-    Route::post('users/{userId}/subscribe', [SubscriptionController::class, 'subscribe']);
-    Route::delete('users/{userId}/unsubscribe', [SubscriptionController::class, 'unSubscribe']);
-    Route::post('users/{userId}/accept-subscription-request', [SubscriptionController::class, 'acceptSubscriptionRequest']);
-    Route::delete('users/{userId}/decline-subscription-request', [SubscriptionController::class, 'declineSubscriptionRequest']);
-    Route::delete('users/{userId}/cancel-subscription-request', [SubscriptionController::class, 'cancelSubscriptionRequest']);
+    // User Relations
+    Route::post('users/{userId}/subscribe', [UsersRelationController::class, 'subscribe']);
+    Route::delete('users/{userId}/unsubscribe', [UsersRelationController::class, 'unSubscribe']);
+    Route::post('users/{userId}/accept-subscription-request', [UsersRelationController::class, 'acceptSubscriptionRequest']);
+    Route::delete('users/{userId}/decline-subscription-request', [UsersRelationController::class, 'declineSubscriptionRequest']);
+    Route::delete('users/{userId}/cancel-subscription-request', [UsersRelationController::class, 'cancelSubscriptionRequest']);
+    Route::post('users/{userId}/block', [UsersRelationController::class, 'blockUser']);
+    Route::delete('users/{userId}/unblock', [UsersRelationController::class, 'unblockUser']);
 
     // notifications 
     Route::get('/me/notifications', [NotificationsController::class, 'index']);
@@ -104,7 +107,7 @@ Route::middleware('auth:sanctum')->group(function () {
     // Report
     Route::post('/submit-report', [ReportController::class, 'submitReport']); 
 
-    Route::delete('remove-follower/{userId}', [SubscriptionController::class, 'removeFollower']);
+    Route::delete('remove-follower/{userId}', [UsersRelationController::class, 'removeFollower']);
 
     // API business routes
     Route::apiResources([


### PR DESCRIPTION
Il faut rejouer les migrations pour pouvoir tester. J'ai renommé l'entité "subscription" => "usersRelations" pour + de cohérence. Car on avait un enum :
$table->enum('status', ['approved', 'pending', 'denied']);
uniquement pour la fonctionnalité de follow. J'ai gardé le même enum en y ajoutant la valeur "blocked":
$table->enum('status', ['approved', 'pending', 'denied', 'blocked']);